### PR TITLE
copy consolidated protocols from correct path

### DIFF
--- a/lib/exrm/plugins/consolidation.ex
+++ b/lib/exrm/plugins/consolidation.ex
@@ -27,7 +27,7 @@ defmodule ReleaseManager.Plugin.Consolidation do
       debug "Packaging consolidated protocols..."
 
       # Add overlay to relx.config which copies consolidated dir to release
-      consolidated_path = Path.join([Mix.Project.build_path, "consolidated"])
+      consolidated_path = Path.join([Mix.Project.build_path, "lib/#{config.name}/consolidated"])
       case File.ls(consolidated_path) do
         {:error, _} ->
           config


### PR DESCRIPTION
Consolidated protocols may have been compiled in another location earlier. 
Copying from current location _build/:env/lib/:project_name/consolidated